### PR TITLE
refactor: CategoryView prefetch에 anotate추가

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -11,9 +11,16 @@ from orders.models   import Cart
 class CategoryView(View):
     def get(self, request):
         categories = Category.objects.all().annotate(
-            product_counts=Count("subcategory__product__id")
-            ).prefetch_related('subcategory_set__product_set')
-            
+            product_counts = Count("subcategory__product__id")
+            ).prefetch_related(
+            Prefetch(
+                'subcategory_set',
+                queryset = SubCategory.objects.annotate(
+                    product_counts=Count("product__id")
+                )
+            )
+        )
+        
         result = [
             {
                 'category_id'    : category.id, 
@@ -27,7 +34,7 @@ class CategoryView(View):
                         'name'           : sub_category.name,
                         'content'        : sub_category.content,
                         'image_url'      : sub_category.image_url,
-                        'products_count' : sub_category.product_set.all().count() 
+                        'products_count' : sub_category.product_counts 
                     } for sub_category in category.subcategory_set.all()
                 ] 
             } for category in categories


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ x ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- CategoryView ORM 최적화

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
### 변경전
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/100751719/192461757-961d0c10-5bce-42d2-bf9a-cf476f6ac2db.png">

- products 테이블을 prefetch 하여 categories, sub_categories, products 에대한 쿼리를 각각1번 총 3번실행

### 변경후
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/100751719/192461896-6d93c5e3-294d-4f5c-a3c9-f786bfac5551.png">

- sub_categories prefetch시에 product.count()함수를 annotate하여 categories, sub_categories 에 대한 쿼리 각각1번 총2번실행